### PR TITLE
Update to UE 4.21

### DIFF
--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/LogitechWheelPlugin.Build.cs
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/LogitechWheelPlugin.Build.cs
@@ -5,12 +5,12 @@ using System.IO;
 
 public class LogitechWheelPlugin : ModuleRules
 {
-	public LogitechWheelPlugin(TargetInfo Target)
-	{
+	public LogitechWheelPlugin(ReadOnlyTargetRules Target) : base(Target)
+    {
 		
 		PublicIncludePaths.AddRange(
 			new string[] {
-				"LogitechWheelPlugin/Public"
+                Path.Combine(ModuleDirectory, "Public"),
 				// ... add public include paths required here ...
 			}
 			);
@@ -18,7 +18,7 @@ public class LogitechWheelPlugin : ModuleRules
 		
 		PrivateIncludePaths.AddRange(
 			new string[] {
-				"LogitechWheelPlugin/Private",
+                Path.Combine(ModuleDirectory, "Private"),
 				// ... add other private include paths required here ...
 			}
 			);

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechBPLibrary.cpp
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechBPLibrary.cpp
@@ -1,9 +1,9 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "LogitechBPLibrary.h"
 #include "LogitechWheelPluginPrivatePCH.h"
 #include "LogitechSteeringWheelLib.h"
 #include "LogitechWheelInputDevice.h"
-#include "LogitechBPLibrary.h"
 
 #define InputDevice ILogitechWheelPlugin::Get()
 

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechBPLibrary.h
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechBPLibrary.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include "Engine.h"
+#include "CoreMinimal.h"
 #include "LogitechSteeringWheelLib.h"
+#include "ILogitechWheelPlugin.h"
 #include "LogitechBPLibrary.generated.h"
 
 /* 

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.cpp
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.cpp
@@ -4,7 +4,7 @@
 #include "LogitechWheelInputDevice.h"
 #include "LogitechSteeringWheelLib.h"
 #include "ILogitechWheelPlugin.h"
-#include "IInputInterface.h"
+#include "GenericPlatform/IInputInterface.h"
 
 #define InputDevice ILogitechWheelPlugin::Get()
 

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.cpp
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "LogitechWheelPluginPrivatePCH.h"
 #include "LogitechWheelInputDevice.h"
+#include "LogitechWheelPluginPrivatePCH.h"
 #include "LogitechSteeringWheelLib.h"
 #include "ILogitechWheelPlugin.h"
 #include "GenericPlatform/IInputInterface.h"

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.h
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "IInputInterface.h"
+#include "GenericPlatform/IInputInterface.h"
 #include "LogitechSteeringWheelLib.h"
 #include "IInputDevice.h"
 //#include "LogitechWheelInputDevice.generated.h"

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.h
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelInputDevice.h
@@ -52,8 +52,8 @@ private:
 	/* Message handler */
 	TSharedRef<FGenericApplicationMessageHandler> MessageHandler;
 
-	void FLogitechWheelInputDevice::SendButtonUpEvent(FKey button);
-	void FLogitechWheelInputDevice::SendButtonDownEvent(FKey button);
-	void FLogitechWheelInputDevice::SendAxisEvent(FKey axis, float value);
+	void SendButtonUpEvent(FKey button);
+	void SendButtonDownEvent(FKey button);
+	void SendAxisEvent(FKey axis, float value);
 
 };

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelPluginPrivatePCH.h
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Private/LogitechWheelPluginPrivatePCH.h
@@ -3,7 +3,7 @@
 #include "Core.h"
 #include "CoreUObject.h"
 #include "Engine.h"
-#include "UnrealMathUtility.h"
+#include "Math/UnrealMathUtility.h"
 #include "ILogitechWheelPlugin.h"
 
 // You should place include statements to your module's private header files here.  You only need to

--- a/LogitechWheelPlugin/Source/LogitechWheelPlugin/Public/ILogitechWheelPlugin.h
+++ b/LogitechWheelPlugin/Source/LogitechWheelPlugin/Public/ILogitechWheelPlugin.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 #include "LogitechWheelPluginPrivatePCH.h"
 #include "LogitechSteeringWheelLib.h"
 #include "IInputDeviceModule.h"


### PR DESCRIPTION
Required changes to header files, module and path handling for UE 4.21 compatibility

Tested with:

- G27
- UE4 Version  4.21.2-4753647+++UE4+Release-4.21, binary distribution from Epic.
- Built using the runuat command line script
- CL 19.16.27027.1 (x64)